### PR TITLE
fix: uniform game tile sizes

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -665,7 +665,7 @@ function GameSelection({ playerName, onChangePlayer }: { playerName: PlayerName;
 
       {/* Games grid */}
       <div className="max-w-5xl mx-auto">
-        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5">
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5">
           <ClickableGameCard
             title="Connect Four"
             description="Drop pieces, connect four in a row. Classic strategy for two."


### PR DESCRIPTION
## Summary
- Changed game grid from 4-column to 3-column layout on large screens
- All 6 game tiles are now the same size (2 rows of 3 instead of 4+2)

## Test plan
- [ ] Verify all tiles appear the same size on desktop
- [ ] Check responsive behavior on mobile (1 col) and tablet (2 col)