### PR TITLE
fix(registry): remove duplicate brace causing build parse error

### DIFF
--- a/src/lib/game-registry.ts
+++ b/src/lib/game-registry.ts
@@ -79,7 +79,6 @@ export const DEFAULT_GAME_ORDER: GameDefinition[] = [
     color: '#9B59B6',
   },
   {
-  {
     slug: 'jeopardy',
     title: 'Jeopardy',
     description: 'Pick categories, answer trivia. Highest score wins the board.',


### PR DESCRIPTION
## Summary
- Removes a stray `{` on line 81 of `src/lib/game-registry.ts` that caused `npm run build` to fail with a parse error
- The duplicate brace was introduced when the jeopardy game entry was added

## Test plan
- [x] `npm run build` passes cleanly